### PR TITLE
Add Trailhead's events

### DIFF
--- a/groups.csv
+++ b/groups.csv
@@ -85,4 +85,5 @@ Startup Weekend Boise,2015-11-19,,Boise,http://www.up.co/communities/usa/boise/s
 Startup Weekend Spokane,2015-11-19,,Spokane,http://www.up.co/communities/usa/spokane/startup-weekend/,,
 THATCamp Boise State,2016-01-12,,Boise,http://thatcamp.org/camps/?region=all&s=Boise,,
 Think Big Festival,2015-04-14,,Coeur d'Alene,http://www.thinkbigfestival.com/,,thinkbigfestival
+Trailhead Events,2016-05-16,,Boise,https://trailheadboise.org/events/,,trailheadboise
 Write The Docs Boise,2016-03-30,,Boise,http://www.meetup.com/Write-the-Docs-Boise/,Write-the-Docs-Boise,


### PR DESCRIPTION
Add Trailhead's events from the Facebook group. I have support for cal feeds on the backlog for gemstate.io but haven't gotten to it yet; this should work for now as long as Trailhead keeps the Facebook events updated. They look pretty similar to what's on the website except w/o the office hours?

Along w/ cal feed support gemstate.io will support multiple events occurring during the day, and more specific name for each event. Until then it'll just list the immediate next event, but that will get people to your Facebook page or Meetup page where they'll see more info.