### PR TITLE
Tune up Boise Startup Week

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -252,7 +252,7 @@
     "id": "70500dab-boise-startupweek",
     "addedDate": "2016-08-23",
     "locality": "Boise",
-    "url": "http://boisestartupweek.org/",
+    "url": "https://boisestartupweek.org/",
     "iCalendarUrl": "https://calendar.google.com/calendar/ical/2l0eaigtdv7s4q0ektbli1m0rk%40group.calendar.google.com/public/basic.ics"
   },
   {

--- a/groups.json
+++ b/groups.json
@@ -253,7 +253,11 @@
     "addedDate": "2016-08-23",
     "locality": "Boise",
     "url": "https://boisestartupweek.org/",
-    "iCalendarUrl": "https://calendar.google.com/calendar/ical/2l0eaigtdv7s4q0ektbli1m0rk%40group.calendar.google.com/public/basic.ics"
+    "iCalendarUrl": "https://calendar.google.com/calendar/ical/2l0eaigtdv7s4q0ektbli1m0rk%40group.calendar.google.com/public/basic.ics",
+    "schedCom": [
+      { "name": "techstarsstartupweekboise2018" },
+      { "name": "techstarsstartupweekboise2019" }
+    ]
   },
   {
     "name": "Boise State ACM-Women",

--- a/groups.schema.json
+++ b/groups.schema.json
@@ -11,6 +11,7 @@
       "locality",
       "addedDate"
     ],
+    "additionalProperties": false,
     "properties": {
       "name": {
         "description": "Full name of the group",
@@ -71,6 +72,7 @@
             "name"
           ]
         },
+        "additionalProperties": false,
         "properties": {
           "name": {
             "type": "string",

--- a/groups.schema.json
+++ b/groups.schema.json
@@ -61,6 +61,22 @@
         "type": "string",
         "format": "date",
         "description": "If a group's no longer meeting, add this to record the last date it was known. This could be helpful in determining past interest, rather than deleting the group entirely. (ISO 8601 format)"
+      },
+      "schedCom": {
+        "description": "If sched.com is used to help people choose sessions within big events, add an item per event here",
+        "type":"array",
+        "items": {
+          "type": "object",
+          "required": [
+            "name"
+          ]
+        },
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Conference name (seen in sched.com URLs as https://<conference_name>.sched.com)"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Added support for sched.com in the schema, added an example for Boise Startup Week.

It is fine to keep the old iCal URL if there might be additional events that don't fit Sched, but soon enough having to have an iCal URL just to get start-end time of these larger events on https://gemstate.io won't be necessary. (A larger event's start/end can be inferred from the start/end of all the sessions on Sched. I am not going to list individual sessions within such a conference on gemstate.io; Sched handles the conference scenario very well.)