### PR TITLE
Improve Hackfort

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -503,7 +503,8 @@
     "locality": "Boise",
     "url": "https://www.treefortmusicfest.com/fort/hackfort/",
     "facebookGroupName": "hackfortfest",
-    "eventbriteOrganizerId": "treefort-music-fest-7469693383"
+    "eventbriteOrganizerId": "treefort-music-fest-7469693383",
+    "eventbriteKeywords": ["hackfort"]
   },
   {
     "name": "HackerX",

--- a/groups.json
+++ b/groups.json
@@ -502,7 +502,8 @@
     "addedDate": "2015-04-14",
     "locality": "Boise",
     "url": "https://www.treefortmusicfest.com/fort/hackfort/",
-    "facebookGroupName": "hackfortfest"
+    "facebookGroupName": "hackfortfest",
+    "eventbriteOrganizerId": "treefort-music-fest-7469693383"
   },
   {
     "name": "HackerX",

--- a/groups.schema.json
+++ b/groups.schema.json
@@ -54,6 +54,13 @@
         "description": "If eventbrite.com is used for scheduling, the Eventbrite organizer ID (typically a number?)",
         "type": "string"
       },
+      "eventbriteKeywords": {
+        "description": "If eventbrite.com is used, a list of keywords used to narrow the events to those specific to this group",
+        "type":"array",
+        "items": {
+          "type": "string"
+        }
+      },
       "iCalendarUrl": {
         "description": "If a generic web calendar is used for scheduling, its iCalendar/RFC5545 URL (e.g. the .ical URLs provided for public Google Calendars)",
         "type": "string"


### PR DESCRIPTION
Hackfort now has EventBrite to go w/ the Facebook info page. Keyworks can be used in the future to filter events down since EventBrite organizers in Idaho tend to be broader than specific groups or topics.